### PR TITLE
Add Mobile virtual keyboard for Text Entry behavior

### DIFF
--- a/Extensions/TextEntryVirtualKeyboard-header.json
+++ b/Extensions/TextEntryVirtualKeyboard-header.json
@@ -1,0 +1,13 @@
+{
+  "shortDescription": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used with Text Entry objects.",
+  "extensionNamespace": "",
+  "fullName": "Mobile virtual keyboard for Text Entry",
+  "name": "TextEntryVirtualKeyboard",
+  "version": "0.0.1",
+  "url": "Extensions/TextEntryVirtualKeyboard.json",
+  "headerUrl": "Extensions/TextEntryVirtualKeyboard-header.json",
+  "tags": "javascript, virtual keyboard, mobile",
+  "eventsBasedBehaviorsCount": 1,
+  "eventsFunctionsCount": 1,
+  "description": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used with Text Entry objects.\n\nActions to open and close the keyboard are added. You can then use the Text Entry as usual."
+}

--- a/Extensions/TextEntryVirtualKeyboard.json
+++ b/Extensions/TextEntryVirtualKeyboard.json
@@ -1,0 +1,306 @@
+{
+  "author": "Bouh",
+  "description": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used with Text Entry objects.\n\nActions to open and close the keyboard are added. You can then use the Text Entry as usual.",
+  "extensionNamespace": "",
+  "fullName": "Mobile virtual keyboard for Text Entry",
+  "name": "TextEntryVirtualKeyboard",
+  "shortDescription": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used with Text Entry objects.",
+  "tags": "javascript, virtual keyboard, mobile",
+  "version": "0.0.1",
+  "eventsFunctions": [
+    {
+      "description": "",
+      "fullName": "",
+      "functionType": "Action",
+      "name": "Function",
+      "sentence": "",
+      "events": [],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "",
+          "name": "",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "sceneName"
+        },
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "",
+          "name": "",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "objectList"
+        }
+      ],
+      "objectGroups": []
+    }
+  ],
+  "eventsBasedBehaviors": [
+    {
+      "description": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used on Text Entry objects.",
+      "fullName": "Mobile virtual keyboard for Text Entry",
+      "name": "TextEntryVirtualKeyboard",
+      "objectType": "TextEntryObject::TextEntry",
+      "eventsFunctions": [
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onCreated",
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "For each object which have this behavior, we create a HTML input with a unique ID. This ID is stored in the object to allow to retrieve the input later.",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SystemInfo::IsMobile"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": "gdjs._extensionMobileKeyboard = gdjs._extensionMobileKeyboard || {};\n\nif (typeof document === \"undefined\") {\n    console.error(\"This behavior is only running in a Browser-like environment\");\n    return;\n}\n\n// Select and focus the input associated to the object when opening the keyboard\ngdjs._extensionMobileKeyboard.openKeyboard = function (eventsFunctionContext) {\n    var uniqueID = gdjs._extensionMobileKeyboard.getUniqueIdInObject(eventsFunctionContext);\n    var input = document.getElementById(uniqueID);\n    if (input) {\n        var textEntry = eventsFunctionContext.getObjects(\"Object\")[0];\n        input.value = textEntry.getString();\n        input.style.removeProperty(\"visibility\");\n        input.focus();\n    }\n}\n\n// Blur the input associated to an ID\ngdjs._extensionMobileKeyboard.closeKeyboardById = function (uniqueID) {\n    var input = document.getElementById(uniqueID);\n    if (input) {\n        input.blur();\n        input.style.setProperty(\"visibility\", \"hidden\");\n    }\n}\n\n// Blur the input associated to an object\ngdjs._extensionMobileKeyboard.closeKeyboard = function (eventsFunctionContext) {\n    var uniqueID = gdjs._extensionMobileKeyboard.getUniqueIdInObject(eventsFunctionContext);\n    var input = document.getElementById(uniqueID);\n    if (input) {\n        var textEntry = eventsFunctionContext.getObjects(\"Object\")[0];\n        textEntry.setString(input.value);\n        input.blur();\n        input.style.setProperty(\"visibility\", \"hidden\");\n    }\n}\n\n// Return the id of the current behavior object\ngdjs._extensionMobileKeyboard.getUniqueIdInObject = function (eventsFunctionContext) {\n    var behaviorName = eventsFunctionContext.getBehaviorName(\"Behavior\");\n    return eventsFunctionContext.getObjects(\"Object\")[0]._mobileKeyboardExtensionInput._uniqueId;\n}\n\n// Save an ID inside the object\nvar setUniqueIdInObject = function (id) {\n    var behaviorName = eventsFunctionContext.getBehaviorName(\"Behavior\");\n    eventsFunctionContext.getObjects(\"Object\")[0]._mobileKeyboardExtensionInput = { \"_uniqueId\": id };\n}\n\n// Create an input for the current object\nconst input = document.createElement(\"input\");\ninput.type = \"text\";\ninput.setAttribute(\"spellcheck\", \"false\"); // Disable spell checking (blue line on mobile under words)\ninput.style = \"background-color: transparent;border: 0px;outline: transparent;color: #0000;\";\n\n// Create an identifier that is unique\nvar uniqueId = \"GDevelop_Mobile_Keyboard_Input\" + Date.now() + '-' + Math.floor(Math.random() * 100000);\ninput.id = uniqueId; // Apply it to the input\nsetUniqueIdInObject(uniqueId); // Apply it to the object\n\ndocument.body.appendChild(input); // Add input to the document HTML\n\n// Handle key presses on the input\ninput.addEventListener(\"keyup\", function (event) {\n    input.focus();\n\n    // Force selection to be at the end (to mimic Text Entry)\n    var length_string = input.value.length;\n    input.setSelectionRange(length_string, length_string);\n\n    // Support for removing the last character\n    if (event.keyCode == 8 || event.keyCode == 46) { // 8=Backspace, 46=Del\n        input.value = input.value.slice(0, -1);\n    }\n\n    var textEntry = eventsFunctionContext.getObjects(\"Object\")[0];\n    textEntry.setString(input.value);//Edit textEntry _str value\n\n    if (event.keyCode === 13) { // 13=Enter key \n        //Send id to function for close keyboard\n        if (gdjs._extensionMobileKeyboard.closeKeyboard != undefined) {\n            gdjs._extensionMobileKeyboard.closeKeyboardById(uniqueId);\n        }\n    }\n}, { passive: false });\n",
+                  "parameterObjects": "",
+                  "useStrict": true
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextEntryObject::TextEntry",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "TextEntryVirtualKeyboard::TextEntryVirtualKeyboard",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Open mobile keyboard",
+          "fullName": "Open mobile keyboard",
+          "functionType": "Action",
+          "name": "openKeyboard",
+          "sentence": "Open mobile keyboard, and save input in _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SystemInfo::IsMobile"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": "gdjs._extensionMobileKeyboard = gdjs._extensionMobileKeyboard || {};\n\nif (gdjs._extensionMobileKeyboard.openKeyboard) { \n    gdjs._extensionMobileKeyboard.openKeyboard(eventsFunctionContext);\n}",
+                  "parameterObjects": "",
+                  "useStrict": true
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextEntryObject::TextEntry",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "TextEntryVirtualKeyboard::TextEntryVirtualKeyboard",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "Close mobile keyboard",
+          "fullName": "Close mobile keyboard",
+          "functionType": "Action",
+          "name": "closeKeyboard",
+          "sentence": "Close mobile keyboard for _PARAM0_",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SystemInfo::IsMobile"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": "gdjs._extensionMobileKeyboard = gdjs._extensionMobileKeyboard || {};\r\n\r\nif (gdjs._extensionMobileKeyboard.closeKeyboard) { \r\n    gdjs._extensionMobileKeyboard.closeKeyboard(eventsFunctionContext);\r\n}",
+                  "parameterObjects": "",
+                  "useStrict": true
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextEntryObject::TextEntry",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "TextEntryVirtualKeyboard::TextEntryVirtualKeyboard",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onOwnerRemovedFromScene",
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "When we delete the object with this behavior, we delete the HTML input linked to it",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SystemInfo::IsMobile"
+                  },
+                  "parameters": [],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [],
+              "events": [
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::JsCode",
+                  "inlineCode": "gdjs._extensionMobileKeyboard = gdjs._extensionMobileKeyboard || {};\n\nvar uniqueID = gdjs._extensionMobileKeyboard.getUniqueIdInObject(eventsFunctionContext);\nvar element = document.getElementById(uniqueID);\nif (element) {\n    element.parentNode.removeChild(element);\n}",
+                  "parameterObjects": "",
+                  "useStrict": true
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "TextEntryObject::TextEntry",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "TextEntryVirtualKeyboard::TextEntryVirtualKeyboard",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "propertyDescriptors": []
+    }
+  ]
+}

--- a/extensions-registry.json
+++ b/extensions-registry.json
@@ -50,6 +50,9 @@
     "positioning",
     "tiles",
     "screen",
+    "javascript",
+    "virtual keyboard",
+    "mobile",
     "time",
     "timer",
     "format",
@@ -231,6 +234,18 @@
       "tags": "positioning, camera, screen",
       "eventsBasedBehaviorsCount": 1,
       "eventsFunctionsCount": 0
+    },
+    {
+      "shortDescription": "Allow to open and close the virtual keyboard on mobile (iOS, Android). To be used with Text Entry objects.",
+      "extensionNamespace": "",
+      "fullName": "Mobile virtual keyboard for Text Entry",
+      "name": "TextEntryVirtualKeyboard",
+      "version": "0.0.1",
+      "url": "Extensions/TextEntryVirtualKeyboard.json",
+      "headerUrl": "Extensions/TextEntryVirtualKeyboard-header.json",
+      "tags": "javascript, virtual keyboard, mobile",
+      "eventsBasedBehaviorsCount": 1,
+      "eventsFunctionsCount": 1
     },
     {
       "shortDescription": "Expressions to transform time in seconds to format like HH:MM:SS. Ideal to display timers on screen.",


### PR DESCRIPTION
Made by @Bouh in https://github.com/4ian/GDevelop-extensions/issues/11

Let's continue the discussion here :)
I've cleaned the extension (double check though that it's still working, because I found something fishy in the closeKeyboardById function => it was refering to the eventsFunctionContext not passed as parameter, which must never be done!).

An example was included in https://github.com/4ian/GDevelop-extensions/issues/11
Ideally, I would like to see how to bundle examples and even documentation - to be sure that it's easy to understand, use and maintain these custom behaviors.