### PR TITLE
Fix bullet not firing on first shot

### DIFF
--- a/Extensions/FireBullet-header.json
+++ b/Extensions/FireBullet-header.json
@@ -3,7 +3,7 @@
   "extensionNamespace": "",
   "fullName": "Fire bullets",
   "name": "FireBullet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "url": "Extensions/FireBullet.json",
   "headerUrl": "Extensions/FireBullet-header.json",
   "tags": "fire, bullets, spawn, firerate,",

--- a/Extensions/FireBullet.json
+++ b/Extensions/FireBullet.json
@@ -6,7 +6,7 @@
   "name": "FireBullet",
   "shortDescription": "Allow the object to fire bullets, with customizable speed, angle and fire rate.",
   "tags": "fire, bullets, spawn, firerate,",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "eventsFunctions": [],
   "eventsBasedBehaviors": [
     {

--- a/Extensions/FireBullet.json
+++ b/Extensions/FireBullet.json
@@ -100,6 +100,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Object",
+              "longDescription": "",
               "name": "Object",
               "optional": false,
               "supplementaryInformation": "",
@@ -109,6 +110,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Behavior",
+              "longDescription": "",
               "name": "Behavior",
               "optional": false,
               "supplementaryInformation": "FireBullet::FireBullet",
@@ -118,6 +120,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "X position, where to create the bullet",
+              "longDescription": "",
               "name": "XPosition",
               "optional": false,
               "supplementaryInformation": "",
@@ -127,6 +130,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Y position, where to create the bullet",
+              "longDescription": "",
               "name": "YPosition",
               "optional": false,
               "supplementaryInformation": "",
@@ -136,6 +140,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "The bullet object",
+              "longDescription": "",
               "name": "Bullet",
               "optional": false,
               "supplementaryInformation": "",
@@ -145,6 +150,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Angle of the bullet, in degrees",
+              "longDescription": "",
               "name": "Angle",
               "optional": false,
               "supplementaryInformation": "",
@@ -154,6 +160,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Speed of the bullet, in pixels per second",
+              "longDescription": "",
               "name": "Speed",
               "optional": false,
               "supplementaryInformation": "",
@@ -225,6 +232,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Object",
+              "longDescription": "",
               "name": "Object",
               "optional": false,
               "supplementaryInformation": "",
@@ -234,6 +242,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Behavior",
+              "longDescription": "",
               "name": "Behavior",
               "optional": false,
               "supplementaryInformation": "FireBullet::FireBullet",
@@ -276,6 +285,7 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Object",
+              "longDescription": "",
               "name": "Object",
               "optional": false,
               "supplementaryInformation": "",
@@ -285,6 +295,59 @@
               "codeOnly": false,
               "defaultValue": "",
               "description": "Behavior",
+              "longDescription": "",
+              "name": "Behavior",
+              "optional": false,
+              "supplementaryInformation": "FireBullet::FireBullet",
+              "type": "behavior"
+            }
+          ],
+          "objectGroups": []
+        },
+        {
+          "description": "",
+          "fullName": "",
+          "functionType": "Action",
+          "name": "onCreated",
+          "sentence": "",
+          "events": [
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "ResetObjectTimer"
+                  },
+                  "parameters": [
+                    "Object",
+                    "\"FireCooldown\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Object",
+              "longDescription": "",
+              "name": "Object",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "object"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Behavior",
+              "longDescription": "",
               "name": "Behavior",
               "optional": false,
               "supplementaryInformation": "FireBullet::FireBullet",
@@ -299,6 +362,7 @@
           "value": "0.1",
           "type": "Number",
           "label": "Cooldown, in seconds, before firing again",
+          "description": "",
           "extraInformation": [],
           "hidden": false,
           "name": "FireCooldown"
@@ -307,6 +371,7 @@
           "value": "",
           "type": "Boolean",
           "label": "",
+          "description": "",
           "extraInformation": [],
           "hidden": true,
           "name": "HasJustFired"

--- a/extensions-registry.json
+++ b/extensions-registry.json
@@ -168,7 +168,7 @@
       "extensionNamespace": "",
       "fullName": "Fire bullets",
       "name": "FireBullet",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "url": "Extensions/FireBullet.json",
       "headerUrl": "Extensions/FireBullet-header.json",
       "tags": "fire, bullets, spawn, firerate,",


### PR DESCRIPTION
Added an onCreated function to reset the timer "FireCooldown" of the
Object as soon as it is created.

Without this, the first attempt to shoot creates the timer, but doesn't
shot because "FireCooldown" seconds haven't passed yet.