### PR TITLE
Add mobile support to clipboard extension

### DIFF
--- a/Extensions/Clipboard-header.json
+++ b/Extensions/Clipboard-header.json
@@ -1,15 +1,15 @@
 {
-  "shortDescription": "Expression returning the content of the clipboard.",
+  "shortDescription": "Read and write the clipboard.",
   "extensionNamespace": "",
   "fullName": "Clipboard",
   "name": "Clipboard",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "url": "Extensions/Clipboard.json",
   "headerUrl": "Extensions/Clipboard-header.json",
-  "tags": "clipboard, pasteboard, paste, write",
+  "tags": "clipboard,pasteboard,paste,copy,write",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/clipboard-text-multiple-outline.svg",
   "eventsBasedBehaviorsCount": 0,
   "eventsFunctionsCount": 3,
-  "description": "This extension adds tools to access the clipboard. It only works on Windows, macOS, Linux and web browsers.",
+  "description": "This extension adds tools to access the clipboard.",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNsaXBib2FyZC10ZXh0LW11bHRpcGxlLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCA3VjIxSDE4VjIzSDRDMi45IDIzIDIgMjIuMSAyIDIxVjdINE0yMCAzQzIxLjEgMyAyMiAzLjkgMjIgNVYxN0MyMiAxOC4xIDIxLjEgMTkgMjAgMTlIOEM2LjkgMTkgNiAxOC4xIDYgMTdWNUM2IDMuOSA2LjkgMyA4IDNIMTEuMThDMTEuNiAxLjg0IDEyLjcgMSAxNCAxQzE1LjMgMSAxNi40IDEuODQgMTYuODIgM0gyME0xNCAzQzEzLjQ1IDMgMTMgMy40NSAxMyA0QzEzIDQuNTUgMTMuNDUgNSAxNCA1QzE0LjU1IDUgMTUgNC41NSAxNSA0QzE1IDMuNDUgMTQuNTUgMyAxNCAzTTEwIDdWNUg4VjE3SDIwVjVIMThWN00xNSAxNUgxMFYxM0gxNU0xOCAxMUgxMFY5SDE4VjExWiIgLz48L3N2Zz4="
 }

--- a/Extensions/Clipboard.json
+++ b/Extensions/Clipboard.json
@@ -1,27 +1,43 @@
 {
   "author": "@Bouh, @arthuro555",
-  "description": "This extension adds tools to access the clipboard. It only works on Windows, macOS, Linux and web browsers.",
+  "description": "This extension adds tools to access the clipboard.",
   "extensionNamespace": "",
   "fullName": "Clipboard",
+  "helpPath": "",
   "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWNsaXBib2FyZC10ZXh0LW11bHRpcGxlLW91dGxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNNCA3VjIxSDE4VjIzSDRDMi45IDIzIDIgMjIuMSAyIDIxVjdINE0yMCAzQzIxLjEgMyAyMiAzLjkgMjIgNVYxN0MyMiAxOC4xIDIxLjEgMTkgMjAgMTlIOEM2LjkgMTkgNiAxOC4xIDYgMTdWNUM2IDMuOSA2LjkgMyA4IDNIMTEuMThDMTEuNiAxLjg0IDEyLjcgMSAxNCAxQzE1LjMgMSAxNi40IDEuODQgMTYuODIgM0gyME0xNCAzQzEzLjQ1IDMgMTMgMy40NSAxMyA0QzEzIDQuNTUgMTMuNDUgNSAxNCA1QzE0LjU1IDUgMTUgNC41NSAxNSA0QzE1IDMuNDUgMTQuNTUgMyAxNCAzTTEwIDdWNUg4VjE3SDIwVjVIMThWN00xNSAxNUgxMFYxM0gxNU0xOCAxMUgxMFY5SDE4VjExWiIgLz48L3N2Zz4=",
   "name": "Clipboard",
   "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/clipboard-text-multiple-outline.svg",
-  "shortDescription": "Expression returning the content of the clipboard.",
-  "tags": "clipboard, pasteboard, paste, write",
-  "version": "0.0.2",
+  "shortDescription": "Read and write the clipboard.",
+  "version": "1.0.0",
+  "tags": [
+    "clipboard",
+    "pasteboard",
+    "paste",
+    "copy",
+    "write"
+  ],
+  "dependencies": [
+    {
+      "exportName": "cordova-clipboard",
+      "name": "Clipboard API Support for mobile",
+      "type": "cordova",
+      "version": "1.3.0"
+    }
+  ],
   "eventsFunctions": [
     {
-      "description": "Read the text from the clipboard asynchronously. As this is \"asynchronous\", this means that the variable won't be immediately filled with the text from the clipboard. Instead, it will be filled a few milliseconds later.\n\nNote also that on some platforms (like on web browsers), the user will be asked for permissions to read from the clipboard.\n\nThis only works on Windows, macOS, Linux and web browsers.",
-      "fullName": "Get text from the clipboard (Windows, macOS, Linux, web browser)",
+      "description": "Read the text from the clipboard asynchronously. As this is \"asynchronous\", this means that the variable won't be immediately filled with the text from the clipboard. Instead, it will be filled a few milliseconds later.\n\nNote also that on web browsers, the user might be asked for permissions to read from the clipboard.",
+      "fullName": "Get text from the clipboard",
       "functionType": "Action",
       "name": "ReadTextCrossPlaform",
+      "private": false,
       "sentence": "Read clipboard and store text in _PARAM1_",
       "events": [
         {
           "disabled": false,
           "folded": false,
           "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst callback =\n    runtimeScene\n        .getVariables()\n        .get(eventsFunctionContext.getArgument(\"callback\"));\n\nif (electron !== null && electron.clipboard)\n    callback.setString(electron.clipboard.readText());\nelse if (\n    typeof navigator !== \"undefined\" &&\n    navigator.clipboard &&\n    navigator.clipboard.readText\n) {\n    navigator.clipboard.readText()\n        .then(text => callback.setString(text))\n        .catch(err =>\n            console.error(\"Error occured while getting clipboard content: \", err.message)\n        );\n} else console.error(\"Unable to read from the clipboard: no method found for this platform.\")\n",
+          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst callback =\n    runtimeScene\n        .getVariables()\n        .get(eventsFunctionContext.getArgument(\"callback\"));\n\nif (electron !== null && electron.clipboard)\n    callback.setString(electron.clipboard.readText());\nelse if (\n    typeof cordova !== \"undefined\" &&\n    cordova.plugins &&\n    cordova.plugins.clipboard\n) cordova.plugins.clipboard.paste(text => callback.setString(text));\nelse if (\n    typeof navigator !== \"undefined\" &&\n    navigator.clipboard &&\n    navigator.clipboard.readText\n) {\n    navigator.clipboard.readText()\n        .then(text => callback.setString(text))\n        .catch(err =>\n            console.error(\"Error occured while getting clipboard content: \", err.message)\n        );\n} else console.error(\"Unable to read from the clipboard: no method found for this platform.\")\n",
           "parameterObjects": "",
           "useStrict": true,
           "eventsSheetExpanded": false
@@ -42,10 +58,43 @@
       "objectGroups": []
     },
     {
+      "description": "Write the text in the clipboard",
+      "fullName": "Write text to the clipboard",
+      "functionType": "Action",
+      "name": "WriteText",
+      "private": false,
+      "sentence": "Write _PARAM1_ to clipboard",
+      "events": [
+        {
+          "disabled": false,
+          "folded": false,
+          "type": "BuiltinCommonInstructions::JsCode",
+          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst text = eventsFunctionContext.getArgument(\"text\");\n\nif (electron !== null && electron.clipboard)\n  electron.clipboard.writeText(text);\nelse if (\n  typeof cordova !== \"undefined\" &&\n  cordova.plugins &&\n  cordova.plugins.clipboard\n) cordova.plugins.clipboard.copy(text);\nelse if (\n  typeof navigator !== \"undefined\" &&\n  navigator.clipboard &&\n  navigator.clipboard.writeText\n) navigator.clipboard\n  .writeText(text)\n  .catch(e => console.error(\"Error while writing clipboard: \", e));\nelse console.error(\"Unable to write to the clipboard: no method found for this platform.\"); \n",
+          "parameterObjects": "",
+          "useStrict": true,
+          "eventsSheetExpanded": false
+        }
+      ],
+      "parameters": [
+        {
+          "codeOnly": false,
+          "defaultValue": "",
+          "description": "Text to write to clipboard",
+          "longDescription": "",
+          "name": "text",
+          "optional": false,
+          "supplementaryInformation": "",
+          "type": "string"
+        }
+      ],
+      "objectGroups": []
+    },
+    {
       "description": "Read the text from the clipboard (Windows, macOS, Linux only)",
       "fullName": "Get text from the clipboard (Windows, macOS, Linux)",
       "functionType": "StringExpression",
       "name": "ReadText",
+      "private": true,
       "sentence": "",
       "events": [
         {
@@ -74,37 +123,6 @@
         }
       ],
       "parameters": [],
-      "objectGroups": []
-    },
-    {
-      "description": "Write the text in the clipboard (Windows, macOS, Linux, web browser only)",
-      "fullName": "Write text to the clipboard (Windows, macOS, Linux, web browser)",
-      "functionType": "Action",
-      "name": "WriteText",
-      "sentence": "Write _PARAM1_ to clipboard",
-      "events": [
-        {
-          "disabled": false,
-          "folded": false,
-          "type": "BuiltinCommonInstructions::JsCode",
-          "inlineCode": "const electron = runtimeScene.getGame().getRenderer().getElectron();\nconst text = eventsFunctionContext.getArgument(\"text\");\n\nif (electron !== null && electron.clipboard)\n  electron.clipboard.writeText(text);\nif (\n  typeof navigator !== \"undefined\" &&\n  navigator.clipboard &&\n  navigator.clipboard.writeText\n) navigator.clipboard\n  .writeText(text)\n  .catch(e => console.error(\"Error while writing clipboard: \", e));\nelse console.error(\"Unable to write to the clipboard: no method found for this platform.\"); \n",
-          "parameterObjects": "",
-          "useStrict": true,
-          "eventsSheetExpanded": false
-        }
-      ],
-      "parameters": [
-        {
-          "codeOnly": false,
-          "defaultValue": "",
-          "description": "Text to write to clipboard",
-          "longDescription": "",
-          "name": "text",
-          "optional": false,
-          "supplementaryInformation": "",
-          "type": "string"
-        }
-      ],
       "objectGroups": []
     }
   ],

--- a/extensions-registry.json
+++ b/extensions-registry.json
@@ -38,6 +38,7 @@
     "clipboard",
     "pasteboard",
     "paste",
+    "copy",
     "write",
     "color",
     "conversion",
@@ -282,14 +283,14 @@
       "eventsFunctionsCount": 0
     },
     {
-      "shortDescription": "Expression returning the content of the clipboard.",
+      "shortDescription": "Read and write the clipboard.",
       "extensionNamespace": "",
       "fullName": "Clipboard",
       "name": "Clipboard",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "url": "Extensions/Clipboard.json",
       "headerUrl": "Extensions/Clipboard-header.json",
-      "tags": "clipboard, pasteboard, paste, write",
+      "tags": "clipboard,pasteboard,paste,copy,write",
       "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/clipboard-text-multiple-outline.svg",
       "eventsBasedBehaviorsCount": 0,
       "eventsFunctionsCount": 3


### PR DESCRIPTION
Adds support via cordova plugins for mobile clipboard, hide deprecated ReadText expression, and bump to version 1.0.0 as I think it can be considered stable and complete as now that all platforms are supported, changes to the API are unlikely. 

Tested on my FairPhone 3.